### PR TITLE
fix: callback not be called of useState's setState(state, callback) when state is same as previous value #7

### DIFF
--- a/src/__tests__/useState.test.ts
+++ b/src/__tests__/useState.test.ts
@@ -60,3 +60,23 @@ it('should callback be called with correct order', () => {
     })
     expect(mockCallback2).toBeCalledTimes(1)
 })
+
+it('`setState` callback should be called once when `state` not changed', () => {
+    const mockCallback = jest.fn()
+
+    const { result } = renderHook(() => {
+        const [count, setCount] = useState(0)
+
+        return { count, setCount }
+    })
+
+    act(() => {
+        result.current.setCount(0, mockCallback)
+    })
+    expect(mockCallback).toBeCalledTimes(1)
+
+    act(() => {
+        result.current.setCount(2)
+    })
+    expect(mockCallback).toBeCalledTimes(1)
+})

--- a/src/useState.ts
+++ b/src/useState.ts
@@ -1,16 +1,25 @@
 import { useState as useStateBasic, useRef, useEffect } from 'react'
+import objectIs from './utils/objectIs'
 
-// const NOOP = () => {}
-type EffectCallback = () => void
+type EffectCallback<S> = ([prevState, currentState]: [S, S]) => void
 type Dispatch<A, B> = (value: A, callback?: B) => void
 type SetStateAction<S> = S | ((prevState: S) => S)
+
+interface CallbackKeeper<S> {
+    cb: EffectCallback<S>
+    prevState: S
+    currentState: S
+}
+
 interface MutableRefObject<T> {
     current: T
 }
 
-function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>, EffectCallback>] {
+function useState<S extends undefined = undefined>(
+    initialState: S
+): [S, Dispatch<SetStateAction<S>, EffectCallback<S>>] {
     const [state, setState] = useStateBasic(initialState)
-    const callbackKeeperRef: MutableRefObject<Array<{ cb: EffectCallback }>> = useRef([])
+    const callbackKeeperRef: MutableRefObject<Array<CallbackKeeper<S>>> = useRef([])
 
     useEffect(() => {
         while (true) {
@@ -19,24 +28,37 @@ function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S
                 break
             }
 
-            cbKeeper.cb()
+            cbKeeper.cb([cbKeeper.prevState, cbKeeper.currentState])
         }
+        // `state` use for corresponding to state and effect
     }, [state])
 
     return [
         state,
-        (s, callback?: EffectCallback) => {
-            if (callback) {
-                if (typeof callback !== 'function') {
-                    throw new Error('The second argument must be a function')
+        (s, callback?: EffectCallback<S>) => {
+            setState(prevState => {
+                const currentState = typeof s === 'function' ? s(prevState) : s
+
+                if (callback) {
+                    if (typeof callback !== 'function') {
+                        throw new Error('The second argument must be a function')
+                    }
+
+                    if (objectIs(prevState, currentState)) {
+                        callback([prevState, currentState])
+                    } else {
+                        // aviod react bat setState
+                        const cbKeeper = {
+                            cb: callback,
+                            prevState,
+                            currentState,
+                        }
+                        callbackKeeperRef.current.push(cbKeeper)
+                    }
                 }
-                // aviod react bat setState
-                const cbKeeper = {
-                    cb: callback,
-                }
-                callbackKeeperRef.current.push(cbKeeper)
-            }
-            setState(s)
+
+                return currentState
+            })
         },
     ]
 }

--- a/src/useState.ts
+++ b/src/useState.ts
@@ -15,7 +15,7 @@ interface MutableRefObject<T> {
     current: T
 }
 
-function useState<S extends undefined = undefined>(
+function useState<S extends any | undefined = undefined>(
     initialState: S
 ): [S, Dispatch<SetStateAction<S>, EffectCallback<S>>] {
     const [state, setState] = useStateBasic(initialState)
@@ -37,7 +37,13 @@ function useState<S extends undefined = undefined>(
         state,
         (s, callback?: EffectCallback<S>) => {
             setState(prevState => {
-                const currentState = typeof s === 'function' ? s(prevState) : s
+                const currentState =
+                    typeof s === 'function'
+                        ? (() => {
+                              const sCb = s as (prevState: S | undefined) => S
+                              return sCb(prevState)
+                          })()
+                        : s
 
                 if (callback) {
                     if (typeof callback !== 'function') {

--- a/src/utils/objectIs.ts
+++ b/src/utils/objectIs.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * inlined Object.is polyfill to avoid requiring consumers ship their own
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+ */
+function is(x: any, y: any) {
+    return (
+        (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y) // eslint-disable-line no-self-compare
+    )
+}
+
+export default typeof Object.is === 'function' ? Object.is : is


### PR DESCRIPTION
This bug can be reproduced when `setState` the same value as before.
Issues #9 